### PR TITLE
Fix OBI calculation bug

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -6,6 +6,7 @@ Handles order book reconstruction and feature calculation.
 import logging
 import time
 from typing import Dict, List, Tuple, Optional, Any, Union
+from collections import OrderedDict, deque
 import numpy as np
 import pandas as pd
 from asyncfix.message import FIXMessage
@@ -476,6 +477,7 @@ class LimitOrderBook:
         ask_vol = sum(sz for _, sz in asks)
         if bid_vol + ask_vol == 0:
             return 0.0
+        return (bid_vol - ask_vol) / (bid_vol + ask_vol)
 
     def get_donchian_channel(self, window: int = 120) -> Tuple[float, float]:
         """


### PR DESCRIPTION
## Summary
- fix missing imports in `data_handler`
- return OBI value in `LimitOrderBook.obi`
- add collection imports for `OrderedDict` and `deque`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684464e6ea888323b4f5eeea18fa685d