### PR TITLE
Fix authentication TargetCompID

### DIFF
--- a/fix_client.py
+++ b/fix_client.py
@@ -98,7 +98,14 @@ class CoinbaseFIXClient:
 
         self.sender_comp_id = config.CB_INTX_SENDER_COMPID
 
-        self.target_comp_id = "CBINTL"
+        if session_type == "order_entry":
+            self.target_comp_id = config.FIX_TARGET_COMPID_ORDER_ENTRY
+        elif session_type == "market_data":
+            self.target_comp_id = config.FIX_TARGET_COMPID_MARKET_DATA
+        elif session_type == "drop_copy":
+            self.target_comp_id = config.FIX_TARGET_COMPID_DROP_COPY
+        else:
+            self.target_comp_id = "CBINTL"
         
         self.target_sub_id = SESSION_SUB_IDS[session_type]
 
@@ -341,11 +348,11 @@ class CoinbaseFIXClient:
             utc_timestamp = self._get_utc_timestamp()
             logger.info(f"Using timestamp for authentication: {utc_timestamp}")
 
-            # Signature format: timestamp + api_key + "CBINTL" + passphrase (always use CBINTL)
-            message = f"{utc_timestamp}{self.api_key}CBINTL{self.passphrase}"
+            # Signature format: timestamp + api_key + TargetCompID + passphrase
+            message = f"{utc_timestamp}{self.api_key}{self.target_comp_id}{self.passphrase}"
             logger.info(
                 f"Authentication message components: timestamp={utc_timestamp}, api_key={self.api_key[:4]}..., "
-                f"target_comp_id=CBINTL, passphrase=***"
+                f"target_comp_id={self.target_comp_id}, passphrase=***"
             )
 
             # Decode the API secret from base64 and create HMAC signature

--- a/test_auth_only.py
+++ b/test_auth_only.py
@@ -36,7 +36,7 @@ SENDER_COMP_ID = os.getenv("CB_INTX_SENDER_COMPID", "")
 
 HOST = "fix.international.coinbase.com"
 PORT = 6120
-TARGET_COMP_ID = "CBINTL"  # Always use CBINTL
+TARGET_COMP_ID = "CBINTLMD"  # Market Data TargetCompID
 TARGET_SUB_ID = "MD"  # Market Data session
 
 async def get_utc_timestamp():
@@ -45,7 +45,7 @@ async def get_utc_timestamp():
 
 async def generate_signature(timestamp, api_key, target_comp_id, passphrase, api_secret):
     """Generate HMAC-SHA256 signature for authentication."""
-    message = f"{timestamp}{api_key}CBINTL{passphrase}"
+    message = f"{timestamp}{api_key}{target_comp_id}{passphrase}"
     logger.info(f"Signature message components: timestamp={timestamp}, api_key={api_key[:4]}..., target_comp_id={target_comp_id}, passphrase=***")
     
     try:


### PR DESCRIPTION
## Summary
- use session-specific `TargetCompID` when initializing Coinbase FIX client
- generate signatures using the selected `TargetCompID`
- update test_auth_only to use correct TargetCompID for Market Data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncfix')*

------
https://chatgpt.com/codex/tasks/task_e_684646b48a308323a44cd353b3111911